### PR TITLE
Return ContainerPort for multicontainer Pod

### DIFF
--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -116,7 +116,7 @@ func TestIfReturnsErroredAnnotationData(t *testing.T) {
 
 }
 
-func TestGetPortWithMultipleContainers(t *testing.T) {
+func TestGetPortFromMultiContainerPod(t *testing.T) {
 	pod := testPod()
 	containerName := "test0"
 	ports := []int32{31111, 32111, 33111}

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -157,7 +157,6 @@ func testPod() *corev1.Pod {
 
 type MockClient struct {
 	client    mock.Mock
-	// k8sClient mock.Mock
 }
 
 func (c *MockClient) GetPod(ctx context.Context) (*corev1.Pod, error) {

--- a/k8s/client_test.go
+++ b/k8s/client_test.go
@@ -116,6 +116,34 @@ func TestIfReturnsErroredAnnotationData(t *testing.T) {
 
 }
 
+func TestGetPortWithMultipleContainers(t *testing.T) {
+	pod := testPod()
+	containerName := "test0"
+	ports := []int32{31111, 32111, 33111}
+	pod.Spec.Containers = []*corev1.Container{
+		{
+			Name: &containerName,
+			Ports: []*corev1.ContainerPort{
+				{ContainerPort: &ports[0]},
+				{ContainerPort: &ports[2]},
+			},
+		},
+	}
+
+	client := &MockClient{}
+	client.client.On("GetPod", context.Background(), "", "").
+		Return(pod, nil).Once()
+
+	clientProvider = func() (Client, error) {
+		return client, nil
+	}
+
+	podInfo, err := GetPodInfo()
+	require.NoError(t, err)
+	require.Equal(t, podInfo.GetDefaultPort(), int(ports[0]))
+
+}
+
 func testPod() *corev1.Pod {
 	return &corev1.Pod{
 		Spec:   &corev1.PodSpec{},
@@ -129,7 +157,7 @@ func testPod() *corev1.Pod {
 
 type MockClient struct {
 	client    mock.Mock
-	k8sClient mock.Mock
+	// k8sClient mock.Mock
 }
 
 func (c *MockClient) GetPod(ctx context.Context) (*corev1.Pod, error) {

--- a/k8s/pod.go
+++ b/k8s/pod.go
@@ -42,9 +42,12 @@ func (pi PodInfo) GetPorts() []*int32 {
 	containers := pi.GetSpec().GetContainers()
 	// TODO(tz) Allow to specify which containers and ports will be registered
 	if len(containers) > 0 {
-		return pi.getPorts(containers[0])
+		for _, container := range containers {
+			if len(container.Ports) > 0 {
+				return pi.getPorts(container)
+			}
+		}
 	}
-
 	return []*int32{}
 }
 

--- a/vaas/client_test.go
+++ b/vaas/client_test.go
@@ -126,8 +126,8 @@ func TestIfBackendLocationIsSetFromVaasResponseHeader(t *testing.T) {
 		} else {
 			w.WriteHeader(http.StatusNotFound)
 		}
-
-		w.Write(mockAddBackendResponse)
+		_, err := w.Write(mockAddBackendResponse)
+		assert.NoError(t, err)
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION
For multicontainer pods the GetDefaultPort method is returning the first containerPort from the first container which has one.