### PR TITLE
Fix version in file name

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,6 +12,11 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: Set Variables
+          id: vars
+          run: |
+            VERSION=$(git describe --tags)
+            echo "::set-output name=version::${VERSION}"
       - name: Build project
         run: |
           make package
@@ -22,7 +27,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
           tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
+          release_name: Release ${{ steps.vars.outputs.version }}
           draft: true
           prerelease: false
       - name: Upload Release Asset
@@ -32,6 +37,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: ./dist/vaas-hook-${{ github.ref }}-linux-amd64.zip
-          asset_name: vaas-hook-${{ github.ref }}-linux-amd64.zip
+          asset_path: ./dist/vaas-hook-${{ steps.vars.outputs.version }}-linux-amd64.zip
+          asset_name: vaas-hook-${{ steps.vars.outputs.version }}-linux-amd64.zip
           asset_content_type: application/zip


### PR DESCRIPTION
GitHub has no tag name in the Workflows/Actions variables, just refs. Actions (like create-release) extract the tag name themselves, so we have to too, as we use it for versioning. 