### PR TITLE
Register backend with InheritTimeProfile equals `true`

### DIFF
--- a/action/register.go
+++ b/action/register.go
@@ -147,7 +147,7 @@ func register(client vaas.Client, cfg CommonConfig, weight int, dcName string, t
 		DirectorURL:        director.ResourceURI,
 		DC:                 *dc,
 		Port:               cfg.Port,
-		InheritTimeProfile: false,
+		InheritTimeProfile: true,
 		Weight:             &weight,
 		Tags:               tags,
 		ResourceURI:        "",


### PR DESCRIPTION
From now each backend will inherit time profile from its own director.